### PR TITLE
Add university selection and leaderboard

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -20,6 +20,8 @@ function App() {
     verified: false,
     name: '',
     leetUsername: '',
+    university: '',
+    customUniversity: '',
   });
   const [groupData, setGroupData] = useState({ code: '', joined: false });
   const [leaderboard, setLeaderboard] = useState([]);
@@ -58,6 +60,8 @@ function App() {
           savedUserData.verified || (savedUserData.leetUsername ? true : false), // Existing users are considered verified
         name: savedUserData.name || '',
         leetUsername: savedUserData.leetUsername || '',
+        university: savedUserData.university || '',
+        customUniversity: savedUserData.customUniversity || '',
       };
       setUserData(updatedUserData);
       console.log('Loaded saved user data:', updatedUserData);
@@ -367,6 +371,7 @@ function App() {
           hard: item.hard ?? 0,
           today: item.today ?? 0,
           xp: item.xp ?? 0, // Include XP from daily challenges
+          university: item.university || '',
         };
       });
       console.log('🔍 [FRONTEND] Normalized leaderboard:', normalized);
@@ -546,6 +551,15 @@ function App() {
               displayNameResult.error
             );
           }
+
+          // Update university
+          if (userData.university) {
+            const uniResult = await window.electronAPI.updateUserUniversity(
+              userData.leetUsername,
+              userData.university
+            );
+            console.log('University update result:', uniResult);
+          }
         } catch (displayNameError) {
           console.error('Error updating user data:', displayNameError);
           // Don't fail the whole process if update fails
@@ -677,7 +691,14 @@ function App() {
 
   // Logout handler
   const handleLogout = () => {
-    setUserData({ email: '', verified: false, name: '', leetUsername: '' });
+    setUserData({
+      email: '',
+      verified: false,
+      name: '',
+      leetUsername: '',
+      university: '',
+      customUniversity: '',
+    });
     setGroupData({ code: '', joined: false });
     setLeaderboard([]);
     setStep('welcome');

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -553,10 +553,14 @@ function App() {
           }
 
           // Update university
-          if (userData.university) {
+          const universityToSave =
+            userData.university === 'other'
+              ? userData.customUniversity
+              : userData.university;
+          if (universityToSave) {
             const uniResult = await window.electronAPI.updateUserUniversity(
               userData.leetUsername,
-              userData.university
+              universityToSave
             );
             console.log('University update result:', uniResult);
           }

--- a/src/components/OnboardingStep.jsx
+++ b/src/components/OnboardingStep.jsx
@@ -80,7 +80,20 @@ const OnboardingStep = ({
             className="border-2 border-black rounded-lg px-3 py-2 w-full focus:border-blue-500 focus:outline-none transition-colors"
             value={userData.university || ''}
             onChange={e => {
-              setUserData({ ...userData, university: e.target.value });
+              const value = e.target.value;
+              if (value === 'other') {
+                setUserData({
+                  ...userData,
+                  university: 'other',
+                  customUniversity: '',
+                });
+              } else {
+                setUserData({
+                  ...userData,
+                  university: value,
+                  customUniversity: '',
+                });
+              }
             }}
           >
             <option value="">No University</option>
@@ -108,7 +121,6 @@ const OnboardingStep = ({
                 setUserData({
                   ...userData,
                   customUniversity: e.target.value,
-                  university: e.target.value,
                 })
               }
             />

--- a/src/components/OnboardingStep.jsx
+++ b/src/components/OnboardingStep.jsx
@@ -71,6 +71,49 @@ const OnboardingStep = ({
             We'll verify this username exists on LeetCode
           </p>
         </div>
+
+        <div>
+          <label className="block text-sm font-bold mb-1">
+            University (optional)
+          </label>
+          <select
+            className="border-2 border-black rounded-lg px-3 py-2 w-full focus:border-blue-500 focus:outline-none transition-colors"
+            value={userData.university || ''}
+            onChange={e => {
+              setUserData({ ...userData, university: e.target.value });
+            }}
+          >
+            <option value="">No University</option>
+            <option value="Massachusetts Institute of Technology">
+              Massachusetts Institute of Technology
+            </option>
+            <option value="Stanford University">Stanford University</option>
+            <option value="Carnegie Mellon University">
+              Carnegie Mellon University
+            </option>
+            <option value="University of California, Berkeley">
+              University of California, Berkeley
+            </option>
+            <option value="Stony Brook University">
+              Stony Brook University
+            </option>
+            <option value="other">My university not listed</option>
+          </select>
+          {userData.university === 'other' && (
+            <input
+              className="border-2 border-black rounded-lg px-3 py-2 w-full mt-2 focus:border-blue-500 focus:outline-none transition-colors"
+              placeholder="Enter your university"
+              value={userData.customUniversity || ''}
+              onChange={e =>
+                setUserData({
+                  ...userData,
+                  customUniversity: e.target.value,
+                  university: e.target.value,
+                })
+              }
+            />
+          )}
+        </div>
       </div>
 
       {error && (

--- a/src/components/leaderboard/FriendsLeaderboard.jsx
+++ b/src/components/leaderboard/FriendsLeaderboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 const RANKS = [
@@ -46,8 +46,16 @@ const FriendsLeaderboard = ({ leaderboard, userData, notifications = [] }) => {
     return `${rankName} ${rankSub}`;
   };
 
-  const uniLeaderboard = leaderboard.filter(
-    u => (u.university || '').toLowerCase() === (userData.university || '').toLowerCase()
+  const userUniversity =
+    userData.university === 'other'
+      ? userData.customUniversity
+      : userData.university;
+  const uniLeaderboard = useMemo(
+    () =>
+      leaderboard.filter(
+        u => (u.university || '').toLowerCase() === (userUniversity || '').toLowerCase()
+      ),
+    [leaderboard, userUniversity]
   );
 
   const renderTable = data => (

--- a/src/components/leaderboard/FriendsLeaderboard.jsx
+++ b/src/components/leaderboard/FriendsLeaderboard.jsx
@@ -41,6 +41,187 @@ const FriendsLeaderboard = ({ leaderboard, userData, notifications = [] }) => {
     return baseXP + bonusXP;
   };
 
+  const renderTable = data => (
+    <div className="h-full overflow-y-auto custom-scrollbar">
+      <table className="min-w-full table-fixed">
+        <thead className="bg-yellow-100 sticky top-0 z-10">
+          <tr className="border-b-2 border-black">
+            <th className="font-bold text-left px-4 py-2 w-16">RANK</th>
+            <th className="font-bold text-left px-4 py-2 w-32">PLAYER</th>
+            <th className="font-bold text-center px-4 py-2 w-16">EASY</th>
+            <th className="font-bold text-center px-4 py-2 w-16">MED</th>
+            <th className="font-bold text-center px-4 py-2 w-16">HARD</th>
+            <th className="font-bold text-center px-4 py-2 w-20">TOTAL</th>
+            <th className="font-bold text-center px-4 py-2 w-24">XP</th>
+          </tr>
+        </thead>
+        <tbody>
+          <AnimatePresence mode="popLayout">
+            {data
+              .sort((a, b) => calculateXP(b) - calculateXP(a))
+              .map((user, index) => {
+                const isCurrentUser =
+                  user.username === userData.leetUsername?.toLowerCase();
+                const total = user.easy + user.medium + user.hard;
+                const userXP = calculateXP(user);
+                const bgColor =
+                  index === 0
+                    ? 'bg-red-100'
+                    : index === 1
+                      ? 'bg-blue-100'
+                      : index === 2
+                        ? 'bg-green-100'
+                        : isCurrentUser
+                          ? 'bg-blue-50 border-l-4 border-blue-400'
+                          : '';
+
+                const textStyle = isCurrentUser
+                  ? 'font-semibold text-blue-700'
+                  : '';
+                const rankStyle = isCurrentUser
+                  ? 'font-bold text-blue-700'
+                  : 'font-bold';
+
+                return (
+                  <motion.tr
+                    key={user.username}
+                    layout
+                    initial={{ opacity: 0, x: -20, scale: 0.95 }}
+                    animate={{
+                      opacity: 1,
+                      x: 0,
+                      scale: 1,
+                      backgroundColor:
+                        index === 0
+                          ? '#fee2e2'
+                          : index === 1
+                            ? '#dbeafe'
+                            : index === 2
+                              ? '#dcfce7'
+                              : isCurrentUser
+                                ? '#eff6ff'
+                                : '#ffffff',
+                    }}
+                    exit={{ opacity: 0, x: 20, scale: 0.95 }}
+                    transition={{
+                      layout: { duration: 0.4, ease: 'easeInOut' },
+                      default: { duration: 0.3 },
+                    }}
+                    className={`border-b border-gray-200 ${bgColor}`}
+                  >
+                    <motion.td className={`px-4 py-3 w-16 ${rankStyle}`} layout>
+                      <motion.span
+                        key={`rank-${index}`}
+                        initial={{ scale: 1.2, color: '#f59e0b' }}
+                        animate={{ scale: 1, color: '#000' }}
+                        transition={{ duration: 0.3 }}
+                      >
+                        #{index + 1}
+                      </motion.span>
+                    </motion.td>
+                    <motion.td className="px-4 py-3 w-32" layout>
+                      <div className="flex items-center gap-2">
+                        <div
+                          className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold border border-black ${isCurrentUser ? 'bg-blue-200 text-blue-800' : 'bg-gray-300'}`}
+                        >
+                          {user.name.substring(0, 2).toUpperCase()}
+                        </div>
+                        <span
+                          className={
+                            isCurrentUser ? 'font-semibold text-blue-700' : ''
+                          }
+                          onMouseEnter={() => setHoveredUser(user.username)}
+                          onMouseLeave={() => setHoveredUser(null)}
+                          style={{ position: 'relative', cursor: 'pointer' }}
+                        >
+                          {isCurrentUser ? 'You' : user.name}
+                          {hoveredUser === user.username && (
+                            <div className="absolute left-1/2 bottom-full z-50 mb-1 -translate-x-1/2 bg-black text-white text-xs rounded px-3 py-1 shadow-lg border-2 border-yellow-300 whitespace-nowrap pointer-events-none animate-fade-in-down">
+                              {(() => {
+                                const xp = calculateXP(user);
+                                const { name: rankName, sub: rankSub } =
+                                  getRankAndSubdivision(xp);
+                                return `${rankName} ${rankSub}`;
+                              })()}
+                            </div>
+                          )}
+                        </span>
+                      </div>
+                    </motion.td>
+                    <motion.td
+                      className={`text-center px-4 py-3 w-16 ${textStyle}`}
+                      layout
+                    >
+                      <motion.span
+                        key={`easy-${user.easy}`}
+                        initial={{ scale: 1.2, color: '#10b981' }}
+                        animate={{ scale: 1, color: '#000' }}
+                        transition={{ duration: 0.3 }}
+                      >
+                        {user.easy}
+                      </motion.span>
+                    </motion.td>
+                    <motion.td
+                      className={`text-center px-4 py-3 w-16 ${textStyle}`}
+                      layout
+                    >
+                      <motion.span
+                        key={`medium-${user.medium}`}
+                        initial={{ scale: 1.2, color: '#f59e0b' }}
+                        animate={{ scale: 1, color: '#000' }}
+                        transition={{ duration: 0.3 }}
+                      >
+                        {user.medium}
+                      </motion.span>
+                    </motion.td>
+                    <motion.td
+                      className={`text-center px-4 py-3 w-16 ${textStyle}`}
+                      layout
+                    >
+                      <motion.span
+                        key={`hard-${user.hard}`}
+                        initial={{ scale: 1.2, color: '#ef4444' }}
+                        animate={{ scale: 1, color: '#000' }}
+                        transition={{ duration: 0.3 }}
+                      >
+                        {user.hard}
+                      </motion.span>
+                    </motion.td>
+                    <motion.td
+                      className={`text-center px-4 py-3 w-20 font-bold ${isCurrentUser ? 'text-blue-700' : 'text-blue-600'}`}
+                      layout
+                    >
+                      <motion.span
+                        key={`total-${total}`}
+                        initial={{ scale: 1.3, color: '#2563eb' }}
+                        animate={{ scale: 1, color: '#000' }}
+                        transition={{ duration: 0.4 }}
+                      >
+                        {total}
+                      </motion.span>
+                    </motion.td>
+                    <motion.td
+                      className={`text-center px-4 py-3 w-24 font-bold ${isCurrentUser ? 'text-purple-700' : 'text-purple-600'}`}
+                      layout
+                    >
+                      <motion.span
+                        key={`xp-${userXP}`}
+                        initial={{ scale: 1.3, color: '#7c3aed' }}
+                        animate={{ scale: 1, color: '#000' }}
+                        transition={{ duration: 0.4 }}
+                      >
+                        {userXP.toLocaleString()}
+                      </motion.span>
+                    </motion.td>
+                  </motion.tr>
+                );
+              })}
+          </AnimatePresence>
+        </tbody>
+      </table>
+    </div>
+  );
+
   // Check if any notification is a 'left' type for this cycle
   const hasLeftNotification = notifications.some(n => n.type === 'left');
   // Filter out overtake notifications if someone left
@@ -117,206 +298,27 @@ const FriendsLeaderboard = ({ leaderboard, userData, notifications = [] }) => {
       </div>
       <div className="flex-1 overflow-hidden">
         {activeTab === 'university' ? (
-          <div className="flex flex-col items-center justify-center h-full text-gray-500 text-lg font-bold">
-            <span>🏫 University Leaderboard</span>
-            <span className="mt-2">Coming soon!</span>
-          </div>
+          (() => {
+            const uniData = leaderboard.filter(
+              u =>
+                (u.university || '').toLowerCase() ===
+                (userData.university || '').toLowerCase()
+            );
+            return uniData.length ? (
+              renderTable(uniData)
+            ) : (
+              <div className="flex flex-col items-center justify-center h-full text-gray-500 text-lg font-bold">
+                <span>🏫 University Leaderboard</span>
+                <span className="mt-2">No players yet!</span>
+              </div>
+            );
+          })()
         ) : leaderboard.length === 0 ? (
           <div className="text-center text-gray-500 py-8">
             No competitors yet! Invite friends to join.
           </div>
         ) : (
-          <div className="h-full overflow-y-auto custom-scrollbar">
-            <table className="min-w-full table-fixed">
-              <thead className="bg-yellow-100 sticky top-0 z-10">
-                <tr className="border-b-2 border-black">
-                  <th className="font-bold text-left px-4 py-2 w-16">RANK</th>
-                  <th className="font-bold text-left px-4 py-2 w-32">PLAYER</th>
-                  <th className="font-bold text-center px-4 py-2 w-16">EASY</th>
-                  <th className="font-bold text-center px-4 py-2 w-16">MED</th>
-                  <th className="font-bold text-center px-4 py-2 w-16">HARD</th>
-                  <th className="font-bold text-center px-4 py-2 w-20">
-                    TOTAL
-                  </th>
-                  <th className="font-bold text-center px-4 py-2 w-24">XP</th>
-                </tr>
-              </thead>
-              <tbody>
-                <AnimatePresence mode="popLayout">
-                  {leaderboard
-                    .sort((a, b) => calculateXP(b) - calculateXP(a))
-                    .map((user, index) => {
-                      const isCurrentUser =
-                        user.username === userData.leetUsername?.toLowerCase();
-                      const total = user.easy + user.medium + user.hard;
-                      const userXP = calculateXP(user);
-                      const bgColor =
-                        index === 0
-                          ? 'bg-red-100'
-                          : index === 1
-                            ? 'bg-blue-100'
-                            : index === 2
-                              ? 'bg-green-100'
-                              : isCurrentUser
-                                ? 'bg-blue-50 border-l-4 border-blue-400'
-                                : '';
-
-                      const textStyle = isCurrentUser
-                        ? 'font-semibold text-blue-700'
-                        : '';
-                      const rankStyle = isCurrentUser
-                        ? 'font-bold text-blue-700'
-                        : 'font-bold';
-
-                      return (
-                        <motion.tr
-                          key={user.username}
-                          layout
-                          initial={{ opacity: 0, x: -20, scale: 0.95 }}
-                          animate={{
-                            opacity: 1,
-                            x: 0,
-                            scale: 1,
-                            backgroundColor:
-                              index === 0
-                                ? '#fee2e2'
-                                : index === 1
-                                  ? '#dbeafe'
-                                  : index === 2
-                                    ? '#dcfce7'
-                                    : isCurrentUser
-                                      ? '#eff6ff'
-                                      : '#ffffff',
-                          }}
-                          exit={{ opacity: 0, x: 20, scale: 0.95 }}
-                          transition={{
-                            layout: { duration: 0.4, ease: 'easeInOut' },
-                            default: { duration: 0.3 },
-                          }}
-                          className={`border-b border-gray-200 ${bgColor}`}
-                        >
-                          <motion.td
-                            className={`px-4 py-3 w-16 ${rankStyle}`}
-                            layout
-                          >
-                            <motion.span
-                              key={`rank-${index}`}
-                              initial={{ scale: 1.2, color: '#f59e0b' }}
-                              animate={{ scale: 1, color: '#000' }}
-                              transition={{ duration: 0.3 }}
-                            >
-                              #{index + 1}
-                            </motion.span>
-                          </motion.td>
-                          <motion.td className="px-4 py-3 w-32" layout>
-                            <div className="flex items-center gap-2">
-                              <div
-                                className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold border border-black ${isCurrentUser ? 'bg-blue-200 text-blue-800' : 'bg-gray-300'}`}
-                              >
-                                {user.name.substring(0, 2).toUpperCase()}
-                              </div>
-                              <span
-                                className={
-                                  isCurrentUser
-                                    ? 'font-semibold text-blue-700'
-                                    : ''
-                                }
-                                onMouseEnter={() =>
-                                  setHoveredUser(user.username)
-                                }
-                                onMouseLeave={() => setHoveredUser(null)}
-                                style={{
-                                  position: 'relative',
-                                  cursor: 'pointer',
-                                }}
-                              >
-                                {isCurrentUser ? 'You' : user.name}
-                                {/* Tooltip for rank */}
-                                {hoveredUser === user.username && (
-                                  <div className="absolute left-1/2 bottom-full z-50 mb-1 -translate-x-1/2 bg-black text-white text-xs rounded px-3 py-1 shadow-lg border-2 border-yellow-300 whitespace-nowrap pointer-events-none animate-fade-in-down">
-                                    {(() => {
-                                      const xp = calculateXP(user);
-                                      const { name: rankName, sub: rankSub } =
-                                        getRankAndSubdivision(xp);
-                                      return `${rankName} ${rankSub}`;
-                                    })()}
-                                  </div>
-                                )}
-                              </span>
-                            </div>
-                          </motion.td>
-                          <motion.td
-                            className={`text-center px-4 py-3 w-16 ${textStyle}`}
-                            layout
-                          >
-                            <motion.span
-                              key={`easy-${user.easy}`}
-                              initial={{ scale: 1.2, color: '#10b981' }}
-                              animate={{ scale: 1, color: '#000' }}
-                              transition={{ duration: 0.3 }}
-                            >
-                              {user.easy}
-                            </motion.span>
-                          </motion.td>
-                          <motion.td
-                            className={`text-center px-4 py-3 w-16 ${textStyle}`}
-                            layout
-                          >
-                            <motion.span
-                              key={`medium-${user.medium}`}
-                              initial={{ scale: 1.2, color: '#f59e0b' }}
-                              animate={{ scale: 1, color: '#000' }}
-                              transition={{ duration: 0.3 }}
-                            >
-                              {user.medium}
-                            </motion.span>
-                          </motion.td>
-                          <motion.td
-                            className={`text-center px-4 py-3 w-16 ${textStyle}`}
-                            layout
-                          >
-                            <motion.span
-                              key={`hard-${user.hard}`}
-                              initial={{ scale: 1.2, color: '#ef4444' }}
-                              animate={{ scale: 1, color: '#000' }}
-                              transition={{ duration: 0.3 }}
-                            >
-                              {user.hard}
-                            </motion.span>
-                          </motion.td>
-                          <motion.td
-                            className={`text-center px-4 py-3 w-20 font-bold ${isCurrentUser ? 'text-blue-700' : 'text-blue-600'}`}
-                            layout
-                          >
-                            <motion.span
-                              key={`total-${total}`}
-                              initial={{ scale: 1.3, color: '#2563eb' }}
-                              animate={{ scale: 1, color: '#000' }}
-                              transition={{ duration: 0.4 }}
-                            >
-                              {total}
-                            </motion.span>
-                          </motion.td>
-                          <motion.td
-                            className={`text-center px-4 py-3 w-24 font-bold ${isCurrentUser ? 'text-purple-700' : 'text-purple-600'}`}
-                            layout
-                          >
-                            <motion.span
-                              key={`xp-${userXP}`}
-                              initial={{ scale: 1.3, color: '#7c3aed' }}
-                              animate={{ scale: 1, color: '#000' }}
-                              transition={{ duration: 0.4 }}
-                            >
-                              {userXP.toLocaleString()}
-                            </motion.span>
-                          </motion.td>
-                        </motion.tr>
-                      );
-                    })}
-                </AnimatePresence>
-              </tbody>
-            </table>
-          </div>
+          renderTable(leaderboard)
         )}
       </div>
     </div>

--- a/src/components/leaderboard/FriendsLeaderboard.jsx
+++ b/src/components/leaderboard/FriendsLeaderboard.jsx
@@ -41,6 +41,15 @@ const FriendsLeaderboard = ({ leaderboard, userData, notifications = [] }) => {
     return baseXP + bonusXP;
   };
 
+  const getRankLabel = xp => {
+    const { name: rankName, sub: rankSub } = getRankAndSubdivision(xp);
+    return `${rankName} ${rankSub}`;
+  };
+
+  const uniLeaderboard = leaderboard.filter(
+    u => (u.university || '').toLowerCase() === (userData.university || '').toLowerCase()
+  );
+
   const renderTable = data => (
     <div className="h-full overflow-y-auto custom-scrollbar">
       <table className="min-w-full table-fixed">
@@ -137,12 +146,7 @@ const FriendsLeaderboard = ({ leaderboard, userData, notifications = [] }) => {
                           {isCurrentUser ? 'You' : user.name}
                           {hoveredUser === user.username && (
                             <div className="absolute left-1/2 bottom-full z-50 mb-1 -translate-x-1/2 bg-black text-white text-xs rounded px-3 py-1 shadow-lg border-2 border-yellow-300 whitespace-nowrap pointer-events-none animate-fade-in-down">
-                              {(() => {
-                                const xp = calculateXP(user);
-                                const { name: rankName, sub: rankSub } =
-                                  getRankAndSubdivision(xp);
-                                return `${rankName} ${rankSub}`;
-                              })()}
+                              {getRankLabel(userXP)}
                             </div>
                           )}
                         </span>
@@ -298,21 +302,14 @@ const FriendsLeaderboard = ({ leaderboard, userData, notifications = [] }) => {
       </div>
       <div className="flex-1 overflow-hidden">
         {activeTab === 'university' ? (
-          (() => {
-            const uniData = leaderboard.filter(
-              u =>
-                (u.university || '').toLowerCase() ===
-                (userData.university || '').toLowerCase()
-            );
-            return uniData.length ? (
-              renderTable(uniData)
-            ) : (
-              <div className="flex flex-col items-center justify-center h-full text-gray-500 text-lg font-bold">
-                <span>🏫 University Leaderboard</span>
-                <span className="mt-2">No players yet!</span>
-              </div>
-            );
-          })()
+          uniLeaderboard.length ? (
+            renderTable(uniLeaderboard)
+          ) : (
+            <div className="flex flex-col items-center justify-center h-full text-gray-500 text-lg font-bold">
+              <span>🏫 University Leaderboard</span>
+              <span className="mt-2">No players yet!</span>
+            </div>
+          )
         ) : leaderboard.length === 0 ? (
           <div className="text-center text-gray-500 py-8">
             No competitors yet! Invite friends to join.

--- a/src/index.js
+++ b/src/index.js
@@ -817,6 +817,7 @@ ipcMain.handle('get-stats-for-group', async (event, groupId) => {
         hard: userData.hard ?? 0,
         today: userData.today ?? 0,
         xp: userData.xp ?? 0, // Include XP from daily challenges and other sources
+        university: userData.university || '',
       };
     })
   );
@@ -925,6 +926,41 @@ ipcMain.handle('update-display-name', async (event, username, displayName) => {
     return { success: false, error: err.message };
   }
 });
+
+// UPDATE UNIVERSITY
+ipcMain.handle(
+  'update-user-university',
+  async (event, username, university) => {
+    console.log(
+      '[DEBUG][update-user-university] called for username:',
+      username,
+      'university:',
+      university
+    );
+
+    const normalizedUsername = username.toLowerCase();
+    const updateParams = {
+      TableName: process.env.USERS_TABLE,
+      Key: { username: normalizedUsername },
+      UpdateExpression: 'SET university = :u',
+      ExpressionAttributeValues: {
+        ':u': university,
+      },
+    };
+
+    try {
+      const updateRes = await ddb.update(updateParams).promise();
+      console.log(
+        '[DEBUG][update-user-university] ddb.update response:',
+        JSON.stringify(updateRes, null, 2)
+      );
+      return { success: true };
+    } catch (err) {
+      console.error('[ERROR][update-user-university] ddb.update error:', err);
+      return { success: false, error: err.message };
+    }
+  }
+);
 
 // Add handler to open URLs in system browser
 ipcMain.handle('open-external-url', async (event, url) => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -122,6 +122,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
     );
   },
 
+  updateUserUniversity: (username, university) => {
+    const validatedUsername = validateInput.username(username);
+    const validatedUniversity =
+      university && typeof university === 'string' ? university.trim() : '';
+    return ipcRenderer.invoke(
+      'update-user-university',
+      validatedUsername,
+      validatedUniversity
+    );
+  },
+
   openExternalUrl: url => {
     const validatedUrl = validateInput.url(url);
     return ipcRenderer.invoke('open-external-url', validatedUrl);


### PR DESCRIPTION
## Summary
- allow setting university during onboarding
- keep university info in user data and persist to DB
- support university update via IPC
- include university when fetching leaderboard
- add University leaderboard tab

## Testing
- `npm test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687b89112fd48321bd1b2b851cd586d4