### PR TITLE
Send discord webhook for account creation

### DIFF
--- a/scripts/fastapi/discord_webhook.py
+++ b/scripts/fastapi/discord_webhook.py
@@ -39,8 +39,7 @@ def send_new_user_notification(username: str, email: str, display_name: str, uni
                     "value": email,
                     "inline": False
                 }
-            ],
-            "timestamp": None  # Discord will add current timestamp
+            ]
         }
 
         # Add university field if provided


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unnecessary timestamp field from Discord webhook embeds, allowing Discord to handle timestamp display natively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->