### PR TITLE
Add dual deployment setup with separate prod/dev instances

### DIFF
--- a/.github/workflows/update-fastapi.yml
+++ b/.github/workflows/update-fastapi.yml
@@ -2,7 +2,7 @@ name: Deploy FastAPI (auto, diff-aware)
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
     paths:
       - 'scripts/fastapi/**'
 
@@ -18,7 +18,23 @@ jobs:
         with:
           fetch-depth: 2
 
-      # 2️⃣ Figure out what changed
+      # 2️⃣ Detect environment (main = prod, dev = dev)
+      - name: Detect environment
+        id: env
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "environment=prod" >> $GITHUB_OUTPUT
+            echo "port=6969" >> $GITHUB_OUTPUT
+            echo "deploy_dir=yeetcode-api" >> $GITHUB_OUTPUT
+            echo "log_file=fastapi.log" >> $GITHUB_OUTPUT
+          else
+            echo "environment=dev" >> $GITHUB_OUTPUT
+            echo "port=42069" >> $GITHUB_OUTPUT
+            echo "deploy_dir=yeetcode-api-dev" >> $GITHUB_OUTPUT
+            echo "log_file=fastapi-dev.log" >> $GITHUB_OUTPUT
+          fi
+
+      # 3️⃣ Figure out what changed
       - name: Detect FastAPI changes
         id: diff
         run: |
@@ -69,20 +85,19 @@ jobs:
           ssh -i ~/.ssh/id_ed25519 -q -o StrictHostKeyChecking=no \
             ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} << 'EOF'
             set -e
-            cd ~/yeetcode-api
+
+            # Detect environment from branch
+            ENV="${{ steps.env.outputs.environment }}"
+            DEPLOY_DIR="${{ steps.env.outputs.deploy_dir }}"
+            LOG_FILE="${{ steps.env.outputs.log_file }}"
+            PORT="${{ steps.env.outputs.port }}"
+
+            # Navigate to correct deployment directory
+            cd ~/$DEPLOY_DIR
 
             # unpack files
             tar -xzf ~/changed-files.tgz -C .
             rm ~/changed-files.tgz
-
-            # load env safely
-            if [ -f .env ]; then
-              # Strip comments, normalize “KEY = VALUE” to “KEY=VALUE”, then export
-              export $(grep -v '^\s*#' .env \
-                        | sed 's/[[:space:]]*=[[:space:]]*/=/g' \
-                        | xargs)
-            fi
-
 
             # reinstall if needed
             if grep -q '^requirements.txt$' ~/changed.txt; then
@@ -91,10 +106,17 @@ jobs:
               pip install -r requirements.txt
             fi
 
-            # restart the app
-            pkill -f 'python3 main.py' || true
+            # restart the app (kill by port to avoid cross-killing)
+            PID=$(lsof -ti:$PORT) || true
+            if [ -n "$PID" ]; then
+              kill $PID
+              sleep 2
+            fi
+
             source .venv/bin/activate
-            nohup python3 main.py > fastapi.log 2>&1 &
+            nohup python3 main.py --env $ENV > $LOG_FILE 2>&1 &
+
+            echo "✅ Deployed $ENV environment to ~/$DEPLOY_DIR (port $PORT)"
           EOF
 
       # 7️⃣ Notify Discord on success
@@ -103,13 +125,20 @@ jobs:
         env:
           WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           CHANGES: ${{ steps.diff.outputs.changed_files }}
+          ENV: ${{ steps.env.outputs.environment }}
+          PORT: ${{ steps.env.outputs.port }}
         run: |
           [ -z "$WEBHOOK" ] && exit 0
           if [ -z "$CHANGES" ]; then
-            CONTENT='🔕 No FastAPI files changed—deploy skipped.'
+            CONTENT="🔕 No FastAPI files changed—deploy skipped ($ENV)."
           else
             ESC=$(printf '%s' "$CHANGES" | sed 's/"/\\"/g')
-            CONTENT="✅ FastAPI deployed with changed files:\n\`\`\`\n$ESC\n\`\`\`"
+            if [ "$ENV" = "prod" ]; then
+              EMOJI="✅"
+            else
+              EMOJI="🚧"
+            fi
+            CONTENT="$EMOJI FastAPI **$ENV** deployed (port $PORT):\n\`\`\`\n$ESC\n\`\`\`"
           fi
           curl -s -X POST -H "Content-Type: application/json" \
                -d "{\"content\":\"$CONTENT\"}" \
@@ -120,8 +149,9 @@ jobs:
         if: failure()
         env:
           WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          ENV: ${{ steps.env.outputs.environment }}
         run: |
           [ -z "$WEBHOOK" ] && exit 0
           curl -s -X POST -H "Content-Type: application/json" \
-               -d '{"content":"❌ FastAPI deploy failed."}' \
+               -d "{\"content\":\"❌ FastAPI **$ENV** deploy failed.\"}" \
                "$WEBHOOK"

--- a/.github/workflows/update-fastapi.yml
+++ b/.github/workflows/update-fastapi.yml
@@ -116,7 +116,30 @@ jobs:
             source .venv/bin/activate
             nohup python3 main.py --env $ENV > $LOG_FILE 2>&1 &
 
-            echo "✅ Deployed $ENV environment to ~/$DEPLOY_DIR (port $PORT)"
+            # Health check loop (30s timeout, 6 attempts with 5s sleep)
+            echo "🔍 Running health check on http://localhost:$PORT/health..."
+            MAX_ATTEMPTS=6
+            ATTEMPT=0
+            HEALTH_OK=false
+
+            while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+              ATTEMPT=$((ATTEMPT + 1))
+              if curl -sf http://localhost:$PORT/health > /dev/null 2>&1; then
+                HEALTH_OK=true
+                break
+              fi
+              echo "  Attempt $ATTEMPT/$MAX_ATTEMPTS failed, waiting 5s..."
+              sleep 5
+            done
+
+            if [ "$HEALTH_OK" = true ]; then
+              echo "✅ Deployed $ENV environment to ~/$DEPLOY_DIR (port $PORT)"
+            else
+              echo "❌ Health check failed after $MAX_ATTEMPTS attempts"
+              echo "📋 Recent logs from $LOG_FILE:"
+              tail -n 50 $LOG_FILE
+              exit 1
+            fi
           EOF
 
       # 7️⃣ Notify Discord on success

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,11 @@ typings/
 # dotenv environment variables file
 .env
 .env.test
+.env.prod
+.env.dev
+scripts/fastapi/.env
+scripts/fastapi/.env.prod
+scripts/fastapi/.env.dev
 
 # Dev config (personal settings, not committed)
 src/dev.config.js

--- a/scripts/fastapi/cache_operations.py
+++ b/scripts/fastapi/cache_operations.py
@@ -52,21 +52,29 @@ def update_user_in_cache(username: str, updates: Dict) -> bool:
         user = next((u for u in users if u.get('username') == username), None)
 
         if not user:
-            # User not in cache - try fetching directly from database
-            # This handles new users who were just created but cache hasn't refreshed yet
-            from aws import UserOperations
-            from logger import info
+            # User not in cache - try fetching from DB with lock to prevent race condition
+            # Use check-after-lock pattern to avoid duplicate fetches
+            with cache_manager._lock:
+                # Re-check if user was added by concurrent request
+                cached_users = cache_manager.get(CacheType.USERS)
+                if cached_users and cached_users.get('success'):
+                    users = cached_users.get('data', [])
+                    user = next((u for u in users if u.get('username') == username), None)
 
-            user = UserOperations.get_user_data(username)
-            if user:
-                info(f"User {username} fetched from DB and added to cache")
-                # Add user to cache
-                users.append(user)
-                cached_users['data'] = users
-                cache_manager.set(CacheType.USERS, cached_users)
-            else:
-                error(f"User {username} not found in cache or database")
-                return False
+                if not user:
+                    # Still not found after re-check - fetch from database
+                    from aws import UserOperations
+                    from logger import info
+
+                    user = UserOperations.get_user_data(username)
+                    if user:
+                        info(f"User {username} fetched from DB and added to cache")
+                        # Add user to in-memory list (write() below handles cache update + WAL)
+                        users.append(user)
+                        cached_users['data'] = users
+                    else:
+                        error(f"User {username} not found in cache or database")
+                        return False
 
         # Apply updates to user
         for key, value in updates.items():

--- a/scripts/fastapi/cache_operations.py
+++ b/scripts/fastapi/cache_operations.py
@@ -48,41 +48,42 @@ def update_user_in_cache(username: str, updates: Dict) -> bool:
 
             info(f"Reloaded {len(normalized_users)} users into cache")
 
-        # Hold lock for entire operation to prevent lost updates from concurrent threads
+        # Pre-check cache and fetch from DB if needed (OUTSIDE lock to avoid blocking)
+        users = cached_users.get('data', [])
+        user = next((u for u in users if u.get('username') == username), None)
+
+        user_from_db = None
+        if not user:
+            # User not in cache - fetch from DB before acquiring lock
+            from aws import UserOperations
+            from logger import info
+
+            user_from_db = UserOperations.get_user_data(username)
+            if not user_from_db:
+                error(f"User {username} not found in cache or database")
+                return False
+
+        # Hold lock for entire update operation to prevent lost updates
         with cache_manager._lock:
+            # Re-fetch cache inside lock (might have been updated by another thread)
+            cached_users = cache_manager.get(CacheType.USERS)
+            if not cached_users or not cached_users.get('success'):
+                error(f"Cache unavailable for user {username}")
+                return False
+
             users = cached_users.get('data', [])
             user = next((u for u in users if u.get('username') == username), None)
 
+            # If user still not in cache but we fetched from DB, add them
+            if not user and user_from_db:
+                info(f"User {username} fetched from DB and added to cache")
+                users.append(user_from_db)
+                cached_users['data'] = users
+                user = user_from_db
+
             if not user:
-                # User not in cache - try fetching from DB
-                # Re-check if user was added by concurrent request
-                re_fetched = cache_manager.get(CacheType.USERS)
-                if re_fetched and re_fetched.get('success'):
-                    # Cache was refreshed, use the new data
-                    cached_users = re_fetched
-                    users = cached_users.get('data', [])
-                    user = next((u for u in users if u.get('username') == username), None)
-
-                if not user:
-                    # Still not found after re-check - fetch from database
-                    from aws import UserOperations
-                    from logger import info
-
-                    user = UserOperations.get_user_data(username)
-                    if user:
-                        info(f"User {username} fetched from DB and added to cache")
-                        # Ensure cached_users is a valid dict before assignment
-                        if not cached_users or not isinstance(cached_users, dict):
-                            cached_users = {"success": True, "data": []}
-                        if 'data' not in cached_users:
-                            cached_users['data'] = []
-                        # Add user to in-memory list (write() below handles cache update + WAL)
-                        users = cached_users['data']
-                        users.append(user)
-                        cached_users['data'] = users
-                    else:
-                        error(f"User {username} not found in cache or database")
-                        return False
+                error(f"User {username} not found in cache")
+                return False
 
             # Apply updates to user
             for key, value in updates.items():

--- a/scripts/fastapi/cache_operations.py
+++ b/scripts/fastapi/cache_operations.py
@@ -48,16 +48,18 @@ def update_user_in_cache(username: str, updates: Dict) -> bool:
 
             info(f"Reloaded {len(normalized_users)} users into cache")
 
-        users = cached_users.get('data', [])
-        user = next((u for u in users if u.get('username') == username), None)
+        # Hold lock for entire operation to prevent lost updates from concurrent threads
+        with cache_manager._lock:
+            users = cached_users.get('data', [])
+            user = next((u for u in users if u.get('username') == username), None)
 
-        if not user:
-            # User not in cache - try fetching from DB with lock to prevent race condition
-            # Use check-after-lock pattern to avoid duplicate fetches
-            with cache_manager._lock:
+            if not user:
+                # User not in cache - try fetching from DB
                 # Re-check if user was added by concurrent request
-                cached_users = cache_manager.get(CacheType.USERS)
-                if cached_users and cached_users.get('success'):
+                re_fetched = cache_manager.get(CacheType.USERS)
+                if re_fetched and re_fetched.get('success'):
+                    # Cache was refreshed, use the new data
+                    cached_users = re_fetched
                     users = cached_users.get('data', [])
                     user = next((u for u in users if u.get('username') == username), None)
 
@@ -69,28 +71,34 @@ def update_user_in_cache(username: str, updates: Dict) -> bool:
                     user = UserOperations.get_user_data(username)
                     if user:
                         info(f"User {username} fetched from DB and added to cache")
+                        # Ensure cached_users is a valid dict before assignment
+                        if not cached_users or not isinstance(cached_users, dict):
+                            cached_users = {"success": True, "data": []}
+                        if 'data' not in cached_users:
+                            cached_users['data'] = []
                         # Add user to in-memory list (write() below handles cache update + WAL)
+                        users = cached_users['data']
                         users.append(user)
                         cached_users['data'] = users
                     else:
                         error(f"User {username} not found in cache or database")
                         return False
 
-        # Apply updates to user
-        for key, value in updates.items():
-            user[key] = value
+            # Apply updates to user
+            for key, value in updates.items():
+                user[key] = value
 
-        # Write back to cache
-        return cache_manager.write(
-            cache_type=CacheType.USERS,
-            data=cached_users,
-            wal_operation={
-                "operation": "UPDATE",
-                "table": USERS_TABLE,
-                "key": {"username": username},
-                "data": user
-            }
-        )
+            # Write back to cache (still inside lock to prevent lost updates)
+            return cache_manager.write(
+                cache_type=CacheType.USERS,
+                data=cached_users,
+                wal_operation={
+                    "operation": "UPDATE",
+                    "table": USERS_TABLE,
+                    "key": {"username": username},
+                    "data": user
+                }
+            )
 
     except Exception as e:
         error(f"Failed to update user in cache: {e}")

--- a/scripts/fastapi/cache_operations.py
+++ b/scripts/fastapi/cache_operations.py
@@ -52,8 +52,21 @@ def update_user_in_cache(username: str, updates: Dict) -> bool:
         user = next((u for u in users if u.get('username') == username), None)
 
         if not user:
-            error(f"User {username} not found in cache")
-            return False
+            # User not in cache - try fetching directly from database
+            # This handles new users who were just created but cache hasn't refreshed yet
+            from aws import UserOperations
+            from logger import info
+
+            user = UserOperations.get_user_data(username)
+            if user:
+                info(f"User {username} fetched from DB and added to cache")
+                # Add user to cache
+                users.append(user)
+                cached_users['data'] = users
+                cache_manager.set(CacheType.USERS, cached_users)
+            else:
+                error(f"User {username} not found in cache or database")
+                return False
 
         # Apply updates to user
         for key, value in updates.items():

--- a/scripts/fastapi/main.py
+++ b/scripts/fastapi/main.py
@@ -4,6 +4,8 @@ FastAPI server for YeetCode email OTP functionality
 """
 
 import os
+import sys
+import argparse
 import asyncio
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -11,8 +13,21 @@ from fastapi import FastAPI, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 
-# Load environment variables
-load_dotenv()
+# Parse command line arguments for environment selection
+parser = argparse.ArgumentParser(description='YeetCode FastAPI Server')
+parser.add_argument('--env', type=str, default='prod', choices=['prod', 'dev'],
+                    help='Environment to run (prod or dev)')
+args, unknown = parser.parse_known_args()
+
+# Load environment-specific .env file
+env_file = f'.env.{args.env}'
+if os.path.exists(env_file):
+    load_dotenv(env_file)
+    print(f"✅ Loaded environment from {env_file}")
+else:
+    # Fallback to default .env
+    load_dotenv()
+    print(f"⚠️ {env_file} not found, using default .env")
 
 # Import routers
 from routes.auth import router as auth_router


### PR DESCRIPTION
## Summary
This PR adds dual deployment setup for production and development environments, deployment health checks, and fixes a critical bug preventing new users from joining groups.

### 1. Dual Deployment Setup
- Modified GitHub workflow to deploy to separate folders (`yeetcode-api` vs `yeetcode-api-dev`)
- Updated `main.py` to support `--env` flag for environment selection
- Separate ports: production (6969) and development (42069)
- Added `.env` file patterns to `.gitignore` for security

### 2. Deployment Health Check
- Added health check loop after `nohup` start in workflow
- Polls `/health` endpoint for up to 30 seconds (6 attempts × 5s sleep)
- On success: prints deployment confirmation
- On failure: outputs last 50 log lines and exits non-zero
- Ensures workflow only succeeds if app is actually running and healthy

### 3. New User Group Join Fix 🐛
**Problem**: New users creating accounts got errors when trying to join groups during onboarding, while existing users could join/leave groups fine.

**Root Cause**: Cache race condition
- User created in DynamoDB → Cache invalidated
- User immediately tries to join group → Not found in cache → Failure

**Solution**: Modified `cache_operations.py` to fetch from database when user not in cache
- If user exists in DB, add them to cache before applying updates
- Only fail if user doesn't exist in database either
- Preserves cache-first architecture while handling race condition

## Files Changed
- `.github/workflows/update-fastapi.yml` - Dual deployment config + health checks
- `scripts/fastapi/main.py` - Environment flag support and port configuration
- `scripts/fastapi/cache_operations.py` - Cache race condition fix
- `.gitignore` - Added .env security patterns

## Test Plan
- [x] Verify production deployment works on port 6969
- [x] Verify dev deployment works on port 42069
- [x] Confirm environment separation
- [x] Test health check succeeds for healthy deployments
- [x] Test health check fails and shows logs for unhealthy deployments
- [ ] Verify new users can join groups during onboarding
- [ ] Verify existing users can still join/leave groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start-up option to select environment (dev/prod) and environment-aware deployment behavior.
  * Deployment now performs post-start health checks and fails if unhealthy.

* **Improvements**
  * Cache update made atomic with lock and DB fallback to populate missing entries; added logging for cache/DB resolution.

* **Chores**
  * CI/CD: dynamic environment detection, environment-specific ports/paths/logging, and enhanced notifications.
  * VCS ignore extended for environment env files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->