### PR TITLE
Add reverse sort to log viewer and environment-aware routing

### DIFF
--- a/scripts/fastapi/routes/admin.py
+++ b/scripts/fastapi/routes/admin.py
@@ -132,13 +132,17 @@ async def serve_log_viewer(
 async def get_log_content(
     api_key: str = Depends(verify_api_key_query)
 ):
-    """Get the raw fastapi.log file content
+    """Get the raw log file content (fastapi.log for prod, fastapi-dev.log for dev)
 
     Access via: /admin/logs/content?api_key=YOUR_API_KEY
     """
     try:
-        # Log file is in the parent directory (scripts/fastapi/../fastapi.log)
-        log_path = os.path.join(os.path.dirname(__file__), "../fastapi.log")
+        # Determine which log file to use based on environment
+        port = os.getenv("PORT", "6969")
+        log_filename = "fastapi-dev.log" if port == "42069" else "fastapi.log"
+
+        # Log file is in the parent directory (scripts/fastapi/../)
+        log_path = os.path.join(os.path.dirname(__file__), f"../{log_filename}")
 
         if not os.path.exists(log_path):
             raise HTTPException(status_code=404, detail=f"Log file not found at {log_path}")

--- a/scripts/fastapi/static/log_viewer.html
+++ b/scripts/fastapi/static/log_viewer.html
@@ -346,6 +346,10 @@
                 <div class="control-group">
                     <button id="refreshBtn" style="margin-top: 23px;">🔄 Refresh Logs</button>
                 </div>
+
+                <div class="control-group">
+                    <button id="reverseSortBtn" style="margin-top: 23px;">⬆️ Oldest First</button>
+                </div>
             </div>
 
             <div class="checkbox-group">
@@ -457,6 +461,7 @@
         let currentOffset = 0;
         const BATCH_SIZE = 100; // Load 100 logs at a time
         let isLoading = false;
+        let isReversed = false; // Latest first by default
 
         const searchInput = document.getElementById('searchInput');
         const usernameFilter = document.getElementById('usernameFilter');
@@ -586,6 +591,9 @@
                     await new Promise(resolve => setTimeout(resolve, 0));
                 }
             }
+
+            // Reverse logs to show latest first by default
+            allLogs.reverse();
 
             statsDiv.style.display = 'grid';
             filterInfo.style.display = 'flex';
@@ -915,6 +923,15 @@
                     console.log(`Loaded ${remaining.toLocaleString()} logs in ${loadTime.toFixed(2)}s`);
                 }
             }
+        });
+
+        // Reverse sort button
+        const reverseSortBtn = document.getElementById('reverseSortBtn');
+        reverseSortBtn.addEventListener('click', () => {
+            isReversed = !isReversed;
+            allLogs.reverse();
+            reverseSortBtn.textContent = isReversed ? '⬇️ Latest First' : '⬆️ Oldest First';
+            filterLogs();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- Added reverse sort functionality to log viewer (latest logs first by default)
- Updated admin logs route to serve environment-specific log files
- Log viewer now serves `fastapi-dev.log` for dev, `fastapi.log` for prod

## Changes
### Log Viewer Improvements ([log_viewer.html](scripts/fastapi/static/log_viewer.html))
- Shows latest logs first by default for easier debugging
- Added toggle button to switch between latest/oldest first sorting
- Better UX for monitoring server logs in real-time

### Environment-Aware Log Routing ([admin.py:132-156](scripts/fastapi/routes/admin.py#L132-L156))
- Admin logs route now checks PORT environment variable
- Serves correct log file based on deployment environment:
  - `fastapi-dev.log` when PORT=42069 (dev environment)
  - `fastapi.log` when PORT=6969 (prod environment)
- Prevents confusion between dev and prod logs

## Testing
- [x] Log viewer displays latest logs first by default
- [x] Toggle button reverses sort order correctly
- [x] Route serves `fastapi-dev.log` when PORT=42069
- [x] Route serves `fastapi.log` when PORT=6969

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Log entries now display newest first by default for easier viewing
  * Added reverse sort toggle to switch between ascending and descending order

* **Chores**
  * Improved log file management with environment-aware selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->