### PR TITLE
Fix duel batch write ValidationException: boolean to numeric conversion error

### DIFF
--- a/scripts/fastapi/cache_operations.py
+++ b/scripts/fastapi/cache_operations.py
@@ -400,6 +400,7 @@ def update_duel_in_cache(duel_id: str, updates: Dict) -> bool:
             duel[key] = value
 
         # Write back to cache
+        # Only send updated fields in WAL to prevent type mismatch errors
         return cache_manager.write(
             cache_type=CacheType.DUELS,
             data=cached_duels,
@@ -407,7 +408,7 @@ def update_duel_in_cache(duel_id: str, updates: Dict) -> bool:
                 "operation": "UPDATE",
                 "table": DUELS_TABLE,
                 "key": {"duelId": duel_id},
-                "data": duel
+                "data": updates  # Only write the fields that were actually updated
             }
         )
 


### PR DESCRIPTION
## Summary
Fixes the `ValidationException` error when creating/updating duels: "The parameter cannot be converted to a numeric value: True"

## Root Cause
The `update_duel_in_cache()` function was sending the entire cached duel object to DynamoDB instead of only the modified fields. This caused type mismatches when cached fields didn't match DynamoDB's expected types.

## Changes
- **File**: `scripts/fastapi/cache_operations.py`
- **Line 411**: Changed `"data": duel` to `"data": updates`
- Now only the explicitly modified fields are sent in the WAL operation, preventing type conflicts from stale cached data
- Matches the pattern already used in `update_user_in_cache()` at line 101

## Testing
After deployment, verify:
1. Create a duel request to a friend
2. Accept the duel
3. Confirm no ValidationException errors in logs
4. Verify duel status updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal cache write operations to improve efficiency and reduce data payload size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->