### PR TITLE
Fix streak showing 0 after daily completion

### DIFF
--- a/scripts/fastapi/routes/daily.py
+++ b/scripts/fastapi/routes/daily.py
@@ -102,13 +102,14 @@ async def complete_daily_problem_endpoint(
     try:
         # Complete the problem in database
         result = DailyProblemOperations.complete_daily_problem(request.username)
-        
+
         # Invalidate cache to force refresh
         cache_manager.invalidate_all(CacheType.DAILY_COMPLETIONS)
         cache_manager.invalidate_all(CacheType.DAILY_PROBLEM)
-        # Also invalidate the user's daily data cache
-        cache_manager.invalidate(CacheType.USER_DAILY_DATA, request.username)
-        
+        # NOTE: Don't invalidate USER_DAILY_DATA - it was just updated by complete_daily_in_cache()
+        # with the new streak value. Invalidating it would cause the next GET to fetch stale data
+        # from the database before WAL has synced.
+
         return result
     except Exception as error:
         return {"success": False, "error": str(error)}


### PR DESCRIPTION
## Summary
Fixes the bug where streak shows as `0` in the API response immediately after completing a daily problem, even though the daily completion is registered successfully.

## Root Cause
The `complete_daily_problem` endpoint was invalidating the `USER_DAILY_DATA` cache **after** `complete_daily_in_cache()` had just updated it with the new streak value.

### Flow Before Fix:
1. `complete_daily_in_cache()` calculates new streak and updates USER_DAILY_DATA cache
2. Complete endpoint returns successfully
3. **Line 110 invalidates the USER_DAILY_DATA cache we just set** ❌
4. Frontend makes GET request for daily data
5. GET finds no USER_DAILY_DATA cache (we just invalidated it)
6. Fetches from DynamoDB with `get_user_daily_data()`
7. DB returns `streak=0` because WAL hasn't synced the write yet
8. User sees `streak: 0` in the UI

## Changes
- **File**: `scripts/fastapi/routes/daily.py`
- **Line 110**: Removed `cache_manager.invalidate(CacheType.USER_DAILY_DATA, request.username)`
- Added explanatory comment about why we don't invalidate this cache

### Flow After Fix:
1. `complete_daily_in_cache()` updates USER_DAILY_DATA cache with new streak
2. Complete endpoint returns successfully
3. Cache remains intact ✅
4. Frontend GET request uses the fresh USER_DAILY_DATA cache
5. User sees correct streak immediately

## Testing
After deployment:
1. Complete a daily problem
2. Immediately refresh/check daily data
3. Verify streak increments correctly (not showing 0)
4. Check that streak persists across app restarts (WAL sync working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency when completing daily problems by refining cache invalidation logic to prevent stale data and ensure accurate synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->