### PR TITLE
🐛 Fix accept-duel failing due to cache invalidation race condition

### DIFF
--- a/scripts/fastapi/cache_operations.py
+++ b/scripts/fastapi/cache_operations.py
@@ -390,13 +390,23 @@ def update_duel_in_cache(duel_id: str, updates: Dict) -> bool:
     """
     try:
         cached_duels = cache_manager.get(CacheType.DUELS)
+
+        # If cache is empty, load duels from DB first
         if not cached_duels or not cached_duels.get('success'):
-            return False
+            from aws import DuelOperations
+            duels_result = DuelOperations.get_all_duels()
+            if not duels_result.get('success'):
+                error("Failed to load duels from DB, cannot update in cache")
+                return False
+            cached_duels = duels_result
+            # Set in cache for future use
+            cache_manager.set(CacheType.DUELS, cached_duels)
 
         duels = cached_duels.get('data', [])
         duel = next((d for d in duels if d.get('duelId') == duel_id), None)
 
         if not duel:
+            error(f"Duel {duel_id} not found in cache after loading from DB")
             return False
 
         # Apply updates

--- a/scripts/fastapi/routes/duels.py
+++ b/scripts/fastapi/routes/duels.py
@@ -91,8 +91,8 @@ async def accept_duel_endpoint(
             request.wager_amount  # Opponent's wager for wager duels
         )
 
-        # Invalidate cache to force refresh
-        cache_manager.invalidate_all(CacheType.DUELS)
+        # NOTE: No need to invalidate cache - cache-first writes handle this automatically
+        # Invalidating causes cache misses for subsequent requests
 
         return result
     except Exception as error:


### PR DESCRIPTION
## 🐛 Bug Fix - Accept Duel Failing

Fixes the "Failed to accept duel in cache" error that was causing socket hang ups.

---

## Problem

Users were unable to accept duels, getting this error:
```
Error: Failed to accept duel in cache
AxiosError: socket hang up (ECONNRESET)
```

### Root Cause

**Cache invalidation race condition:**

1. `accept-duel` endpoint called `cache_manager.invalidate_all(CacheType.DUELS)` after every accept
2. Next accept-duel request found empty DUELS cache
3. `update_duel_in_cache()` returned `False` when cache was empty  
4. Accept failed with "Failed to accept duel in cache" error

### Timeline
```
Request 1: Accept duel → Success → Invalidate DUELS cache
Request 2: Accept duel → Cache empty → update_duel_in_cache() returns False → ERROR
```

---

## Solution

### 1. Made `update_duel_in_cache()` Resilient to Cache Misses

**File**: [cache_operations.py:394-403](scripts/fastapi/cache_operations.py#L394-L403)

**Before**: Returned `False` if cache was empty  
**After**: Loads duels from DB and repopulates cache

```python
# If cache is empty, load duels from DB first
if not cached_duels or not cached_duels.get('success'):
    from aws import DuelOperations
    duels_result = DuelOperations.get_all_duels()
    if not duels_result.get('success'):
        error("Failed to load duels from DB, cannot update in cache")
        return False
    cached_duels = duels_result
    # Set in cache for future use
    cache_manager.set(CacheType.DUELS, cached_duels)
```

### 2. Removed Unnecessary Cache Invalidation

**File**: [duels.py:94-95](scripts/fastapi/routes/duels.py#L94-L95)

**Removed**:
```python
# Invalidate cache to force refresh
cache_manager.invalidate_all(CacheType.DUELS)
```

**Why**: Cache-first writes handle updates automatically via dirty flags. Invalidation was causing unnecessary cache misses.

---

## Impact

✅ **Accept-duel works reliably** even when cache is empty  
✅ **No more socket hang up errors**  
✅ **Cache stays populated** for better performance  
✅ **Graceful fallback** to DB when cache is unavailable  

---

## Testing

**Before Fix**:
- Accept duel → "Failed to accept duel in cache" error
- Backend returns 200 OK but frontend gets socket hang up
- Only worked intermittently

**After Fix**:
- Accept duel → Success
- Cache automatically repopulates if empty
- Consistent behavior

---

## Files Changed

1. `scripts/fastapi/cache_operations.py` - Auto-load duels on cache miss
2. `scripts/fastapi/routes/duels.py` - Remove cache invalidation

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of duel acceptance through enhanced cache refresh handling.
  * Better error detection when cache operations encounter data inconsistencies.

* **Performance**
  * Optimized cache operations to reduce unnecessary data transfers and improve system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->