### PR TITLE
[PHASE 1 CRITICAL] Stop cache invalidation data loss

### DIFF
--- a/scripts/fastapi/routes/bounties.py
+++ b/scripts/fastapi/routes/bounties.py
@@ -120,10 +120,15 @@ async def refresh_bounty_cache_endpoint(
 ):
     """Force refresh bounty and bounty competition caches"""
     try:
-        # Invalidate both bounty caches
+        # NOTE: This is an explicit admin refresh endpoint, so invalidation is intentional
+        # However, we should dump dirty data first to prevent data loss
+        from cache_dumper import dump_cache_to_db
+        await dump_cache_to_db()
+
+        # Now safe to invalidate both bounty caches
         cache_manager.invalidate_all(CacheType.BOUNTIES)
         cache_manager.invalidate_all(CacheType.BOUNTY_COMPETITIONS)
-        
+
         return {"success": True, "message": "Bounty caches refreshed"}
     except Exception as error:
         return {"success": False, "error": str(error)}

--- a/scripts/fastapi/routes/daily.py
+++ b/scripts/fastapi/routes/daily.py
@@ -103,12 +103,10 @@ async def complete_daily_problem_endpoint(
         # Complete the problem in database
         result = DailyProblemOperations.complete_daily_problem(request.username)
 
-        # Invalidate cache to force refresh
-        cache_manager.invalidate_all(CacheType.DAILY_COMPLETIONS)
-        cache_manager.invalidate_all(CacheType.DAILY_PROBLEM)
-        # NOTE: Don't invalidate USER_DAILY_DATA - it was just updated by complete_daily_in_cache()
-        # with the new streak value. Invalidating it would cause the next GET to fetch stale data
-        # from the database before WAL has synced.
+        # NOTE: No cache invalidation - complete_daily_in_cache() uses cache-first writes
+        # DAILY_PROBLEM, DAILY_COMPLETIONS, and USER_DAILY_DATA caches are all updated in-place
+        # Invalidating would destroy uncommitted streak/XP data before WAL can sync to DB
+        # Let cache TTL handle expiration naturally
 
         return result
     except Exception as error:

--- a/scripts/fastapi/routes/duels.py
+++ b/scripts/fastapi/routes/duels.py
@@ -70,8 +70,8 @@ async def create_duel_endpoint(
             request.wager_amount
         )
 
-        # Invalidate cache to force refresh
-        cache_manager.invalidate_all(CacheType.DUELS)
+        # NOTE: No cache invalidation - create_duel uses cache-first writes
+        # Cache is updated in-place, invalidation would destroy uncommitted data
 
         return result
     except Exception as error:
@@ -107,10 +107,10 @@ async def start_duel_endpoint(
     """Mark that a user has started working on a duel"""
     try:
         result = DuelOperations.start_duel(request.username, request.duel_id)
-        
-        # Invalidate cache to force refresh
-        cache_manager.invalidate_all(CacheType.DUELS)
-        
+
+        # NOTE: No cache invalidation - start_duel uses cache-first writes
+        # Cache is updated in-place via update_duel_in_cache()
+
         return result
     except Exception as error:
         return {"success": False, "error": str(error)}
@@ -125,10 +125,10 @@ async def complete_duel_endpoint(
     try:
         # Legacy endpoint - redirects to record submission
         result = DuelOperations.record_duel_submission(request.username, request.duel_id, 0)
-        
-        # Invalidate cache to force refresh
-        cache_manager.invalidate_all(CacheType.DUELS)
-        
+
+        # NOTE: No cache invalidation - record_duel_submission uses cache-first writes
+        # Cache is updated in-place via update_duel_in_cache()
+
         return result
     except Exception as error:
         return {"success": False, "error": str(error)}
@@ -146,10 +146,10 @@ async def reject_duel_endpoint(
             return {"success": False, "error": "Duel ID required"}
         
         result = DuelOperations.reject_duel(duel_id)
-        
-        # Invalidate cache to force refresh
-        cache_manager.invalidate_all(CacheType.DUELS)
-        
+
+        # NOTE: No cache invalidation - reject_duel uses cache-first writes
+        # Cache is updated in-place via delete_duel_from_cache()
+
         return result
     except Exception as error:
         return {"success": False, "error": str(error)}
@@ -170,10 +170,10 @@ async def record_duel_submission_endpoint(
             return {"success": False, "error": "Duel ID and username required"}
         
         result = DuelOperations.record_duel_submission(username, duel_id, elapsed_ms)
-        
-        # Invalidate cache to force refresh
-        cache_manager.invalidate_all(CacheType.DUELS)
-        
+
+        # NOTE: No cache invalidation - record_duel_submission uses cache-first writes
+        # Cache is updated in-place via update_duel_in_cache()
+
         return result
     except Exception as error:
         return {"success": False, "error": str(error)}


### PR DESCRIPTION
## 🚨 CRITICAL FIX - Deploy Immediately

This PR implements **Phase 1** of the comprehensive cache fix plan (see `CACHE_FIX_PLAN.md`) to stop ongoing data loss in production.

## The Problem

All write endpoints were calling `cache_manager.invalidate_all()` immediately after updating the cache, which **deleted the fresh data we just wrote** before it could be synced to DynamoDB.

### Current Broken Flow:
```python
# Example: Creating a duel
create_duel(...)
  → Updates cache: [duel1, duel2, NEW_DUEL] ✅ Fresh data
  → Marks entry as dirty for WAL sync
  
cache_manager.invalidate_all(DUELS) ❌ DELETES cache we just updated!

# User immediately checks duels:
get_duels()
  → Cache miss (we deleted it)
  → Reads from DB
  → DB doesn't have new duel (WAL runs every 30s, hasn't synced yet)
  → Returns: [duel1, duel2] (missing NEW_DUEL)
  → User sees error: "Duel not found" ❌
```

## Why This Causes Data Loss

The cache-first architecture means:
1. **Cache = source of truth** between write and WAL sync
2. WAL background task syncs dirty entries to DB every 30 seconds
3. Invalidating cache = destroying uncommitted data
4. If server crashes in that 30s window → data permanently lost

### Real-World Impact:
- **Streaks reset to 0** - User completes daily, streak saved to cache, cache invalidated, server restarts, streak lost
- **Duels fail** - Create duel, cache invalidated, opponent tries to accept, duel not found in DB yet
- **XP inconsistencies** - Different leaderboards read at different times, some hit cache (fresh), some hit DB (stale)
- **Daily completions give 0 XP** - XP written to cache, cache invalidated, background task reads stale DB value

## The Solution

**Remove all cache invalidations from write endpoints.**

Why this works:
```python
# After this fix:
create_duel(...)
  → Updates cache: [duel1, duel2, NEW_DUEL] ✅ Fresh data
  → Marks entry as dirty for WAL sync
  
# NO invalidation → cache stays fresh ✅

# User immediately checks duels:
get_duels()
  → Cache hit! Returns [duel1, duel2, NEW_DUEL] ✅
  → User sees new duel immediately
  
# 30 seconds later:
WAL syncs to DB → DB now has [duel1, duel2, NEW_DUEL] ✅
```

## "Won't the cache be stale?"

**NO** - and this is the key insight:

- When we write to cache, **we update it with fresh data**
- The cache contains the **latest, most correct data**  
- Invalidating would force reads to go to the **stale database** instead
- Cache TTL naturally expires old entries (configured per cache type)

The cache-first pattern means the cache should stay warm with fresh data, not be constantly invalidated.

## Changes Made

### Files Modified:
- `routes/duels.py` - Removed 5 invalidation calls from duel endpoints
- `routes/daily.py` - Removed 2 invalidation calls from daily completion
- `routes/bounties.py` - Added dump before invalidation in admin refresh endpoint

### Endpoints Fixed:
- ✅ `/create-duel` - No longer invalidates after creation
- ✅ `/accept-duel` - Already fixed in PR #27
- ✅ `/start-duel` - No longer invalidates after starting
- ✅ `/complete-duel` - No longer invalidates after completion
- ✅ `/reject-duel` - No longer invalidates after rejection
- ✅ `/record-duel-submission` - No longer invalidates after recording
- ✅ `/complete-daily-problem` - No longer invalidates DAILY_PROBLEM/DAILY_COMPLETIONS
- ⚠️ `/refresh-bounty-cache` - Still invalidates but dumps dirty data first (admin endpoint)

## Expected Improvements

After deploying this PR, you should see:

✅ **Streaks persist** across server restarts  
✅ **Daily completions award 200 XP** immediately and correctly  
✅ **Duels work end-to-end** - create/accept/complete all work  
✅ **Consistent XP** across all leaderboard views  
✅ **Zero warnings** - No more "⚠️ Invalidating dirty cache entry" in logs  
✅ **Faster responses** - Cache hits instead of DB reads

## Testing Plan

### 1. Test Streak Persistence
```bash
# Complete daily problem
curl -X POST "/complete-daily-problem" -d '{"username":"testuser"}'

# Check streak
curl -X GET "/daily-problem/testuser"
# Should show: streak = 1

# Restart server (simulates crash)
# ... restart ...

# Check streak again
curl -X GET "/daily-problem/testuser"  
# Should STILL show: streak = 1 ✅ (not 0)
```

### 2. Test Duel Flow
```bash
# Create duel
curl -X POST "/create-duel" -d '{...}'

# Immediately check duels
curl -X GET "/duels/testuser"
# Should show new duel ✅ (not empty)

# Accept duel
curl -X POST "/accept-duel" -d '{...}'

# Complete duel  
curl -X POST "/record-duel-submission" -d '{...}'

# All updates should persist
```

### 3. Monitor Logs
```bash
# Should see ZERO of these warnings:
grep "⚠️ Invalidating dirty" /root/fastapi.log
```

## Rollback Plan

If any issues occur after deployment:

```bash
# 1. Revert this PR
git revert <commit-hash>
git push

# 2. Manually dump and clear cache to recover
curl -X POST "/cache/dump" -H "Authorization: Bearer $API_KEY"
curl -X POST "/cache/clear" -H "Authorization: Bearer $API_KEY"
```

## Architecture Documentation

See `CACHE_FIX_PLAN.md` for:
- Full root cause analysis
- Phase 2 & 3 improvements (immediate WAL sync, cache warming, etc.)
- Long-term monitoring and health checks

## Related Issues

Fixes:
- Streak resetting to 0 on restart
- Duels not accepting
- XP discrepancies between leaderboards  
- Daily completions giving 0 XP

Related PRs:
- PR #26 - Fixed USER_DAILY_DATA invalidation
- PR #27 - Fixed accept-duel cache miss

---

**Priority**: 🚨 CRITICAL - Active data loss  
**Risk**: ✅ Low - Only removes harmful invalidations  
**Complexity**: ✅ Low - Simple removals + comments  
**Impact**: 🎯 High - Fixes 4+ major bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized cache management across bounties, daily problems, and duel endpoints to improve data consistency and system performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->