### PR TITLE
Fix: Phase 2 WAL dump bugs and add cache viewer

### DIFF
--- a/scripts/fastapi/static/log_viewer.html
+++ b/scripts/fastapi/static/log_viewer.html
@@ -444,6 +444,16 @@
             color: #858585;
             font-size: 11px;
         }
+
+        #dirtyEntriesContainer {
+            max-height: 400px;
+            overflow-y: auto;
+        }
+
+        #cacheKeysContainer {
+            max-height: 600px;
+            overflow-y: auto;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Fixed cache_manager method name bug in admin endpoint (`get_stats()` → `get_cache_stats()`)
- Added cache viewer tab to log viewer HTML for debugging
- Added scrolling to cache viewer containers

## Changes
- [routes/admin.py](scripts/fastapi/routes/admin.py#L177): Fixed method call to use correct `get_cache_stats()` method name
- [static/log_viewer.html](scripts/fastapi/static/log_viewer.html): Added cache status viewer tab with stats display and scrollable containers
- Removed CACHE_FIX_PLAN.md (no longer needed)

## Test plan
- [x] Verify cache viewer loads without errors
- [x] Check cache statistics display correctly
- [x] Test WAL status display
- [x] Verify dirty entries tracking with scrolling
- [x] Test manual cache dump button
- [x] Confirm containers scroll properly with many entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)